### PR TITLE
Added EXR support

### DIFF
--- a/io.github.f3d_app.f3d.yaml
+++ b/io.github.f3d_app.f3d.yaml
@@ -333,6 +333,20 @@ modules:
           stable-only: true
           url-template: https://github.com/alembic/alembic/archive/refs/tags/$version.tar.gz
 
+  - name: libdeflate
+    buildsystem: cmake-ninja
+    sources:
+    - type: archive
+      url: https://github.com/ebiggers/libdeflate/releases/download/v1.20/libdeflate-1.20.tar.gz
+      sha256: c52cf0239fd644d71c9e88613dd7431a5306ebee1280c5791c71ca264869250a
+
+  - name: openexr
+    buildsystem: cmake-ninja
+    sources:
+    - type: archive
+      url: https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.2.4.tar.gz
+      sha256: 81e6518f2c4656fdeaf18a018f135e96a96e7f66dbe1c1f05860dd94772176cc
+
   - name: F3D
     buildsystem: cmake-ninja
     builddir: true
@@ -343,6 +357,7 @@ modules:
     config-opts:
       - -DCMAKE_INSTALL_PREFIX:PATH=/app
       - -DBUILD_TESTING:BOOL=OFF
+      - -DF3D_MODULE_EXR:BOOL=ON
       - -DF3D_LINUX_INSTALL_DEFAULT_CONFIGURATION_FILE_IN_PREFIX:BOOL=ON
       - -DF3D_PLUGINS_STATIC_BUILD=ON
       - -DF3D_PLUGIN_BUILD_ALEMBIC=ON


### PR DESCRIPTION
Hello, I have made an [app](https://flathub.org/apps/io.github.nokse22.Exhibit) that uses F3D and I used your manifest to build libf3d (thanks), but I noticed it was missing support for EXR images.